### PR TITLE
Modification to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@ from hszinc import __version__
 
 setup (name = 'hszinc',
         version = __version__,
-	packages = [
+        packages = [
             'hszinc',
         ],
-        requires=[
+        install_requires =[
             'parsimonious',
             'pytz',
             'iso8601',


### PR DESCRIPTION
When installing hszonc as a dependency for pyhaystack in TravisCI with pip, hszinc fails because dependencies are not installed.

I modified setup.py to include install_requires instead of requires only
