### PR TITLE
Figured what was the problem when installing with pip.

### DIFF
--- a/hszinc/__init__.py
+++ b/hszinc/__init__.py
@@ -23,6 +23,6 @@ __author__ = 'VRT Systems'
 __copyright__ = 'Copyright 2016, VRT Systems'
 __credits__ = ['VRT Systems']
 __license__ = 'BSD'
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 __maintainer__ = 'VRT Systems'
 __email__ = 'support@vrt.com.au'

--- a/hszinc/datatypes.py
+++ b/hszinc/datatypes.py
@@ -240,6 +240,9 @@ class Quantity(object):
         else:
             return 1
 
+    def __hash__(self):
+        return hash((self.value, self.unit))
+
 
 class Coordinate(object):
     '''


### PR DESCRIPTION
In the setup.py, you were importing from hszinc import **version**. Importing the package was creating a dependency for parsimonious and other packages that are not yet installed (caused by **init**.py)... making the setup to fail before being able to install the dependencies.
I've moved **version** and other informations into a infos.py at root level so it can be imported without importing the hszinc package.
Little tweaks to requirements.txt and setup.py and now I can `pip install .` without any problem.

Signed-off-by: Christian Tremblay christian.tremblay@servisys.com
