### PR TITLE
Add dict

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ docs/_build/
 # PyBuilder
 target/
 
+# Pycharm
+.idea
+
 # vi swapfiles
 .*.sw?
 *.sw?

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "pypy"
   - "pypy3"
 # command to install dependencies

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,10 @@
 HSZinc
 ======
 
-.. image:: https://travis-ci.org/vrtsystems/hszinc.svg?branch=master
-    :target: https://travis-ci.org/vrtsystems/hszinc
-.. image:: https://coveralls.io/repos/vrtsystems/hszinc/badge.svg?branch=master&service=github
-    :target: https://coveralls.io/github/vrtsystems/hszinc?branch=master
+.. image:: https://travis-ci.org/widesky/hszinc.svg?branch=master
+    :target: https://travis-ci.org/widesky/hszinc
+.. image:: https://coveralls.io/repos/widesky/hszinc/badge.svg?branch=master&service=github
+    :target: https://coveralls.io/github/widesky/hszinc?branch=master
 
 HSZinc is an implementation of the `ZINC`_ grid serialisation format used in
 `Project Haystack`_.  Additionally, the module implements code for parsing and
@@ -182,11 +182,12 @@ Null, Boolean, Date, Time, Date/Time and strings.
 Numbers
   Numbers without a unit are represented as `float` objects.
   Numbers with a unit are represented by the `hszinc.Quantity` custom type which
-  has two attributes: `value` and `unit`.
+  has two attributes: `value` and `unit`.  If `pint` is installed, support exists
+  for its unit conversion features.
 
-Marker and Remove
-  These are singletons, represented by `hszinc.MARKER` and `hszinc.REMOVE`.
-  They behave and are intended to be used like the `None` object.
+NA, Marker and Remove
+  These are singletons, represented by `hszinc.NA`, `hszinc.MARKER` and
+  `hszinc.REMOVE`.  They behave and are intended to be used like the `None` object.
 
 URI and Bin
   These are represented as subclasses of `unicode` type (Python 2.7; `str` in
@@ -200,10 +201,17 @@ Coord
   Represented by the custom type `hszinc.Coordinate`, which has `latitude` and
   `longitude` types (both `float`)
 
+Lists
+  Represented using standard Python `list` objects.
+
 STATUS
 ======
 
-This is early days, absolutely nothing is guaranteed.
+`hszinc` has been used to implement the core grid parsing logic in `pyhaystack`
+and used in production for some time now.  Project Haystack 2.0 compatibility
+is pretty good at this time, with 3.0 being a work-in-progress.  (At the moment
+we support lists, the NA singleton, and both variants of the Remove singleton
+when using JSON serialisation.)
 
 .. _`Project Haystack`: http://www.project-haystack.org/
 .. _`ZINC`: http://project-haystack.org/doc/Zinc

--- a/hszinc/__init__.py
+++ b/hszinc/__init__.py
@@ -43,6 +43,6 @@ __author__ = 'VRT Systems'
 __copyright__ = 'Copyright 2016, VRT Systems'
 __credits__ = ['VRT Systems']
 __license__ = 'BSD'
-__version__ = '1.2.3'
+__version__ = '1.3.0a1'
 __maintainer__ = 'VRT Systems'
 __email__ = 'support@vrt.com.au'

--- a/hszinc/__init__.py
+++ b/hszinc/__init__.py
@@ -23,12 +23,13 @@ try:
     from .dumper import dump, dump_scalar
     from .parser import parse, parse_scalar, MODE_JSON, MODE_ZINC
     from .metadata import MetadataObject
-    from .datatypes import Quantity, Coordinate, Uri, Bin, MARKER, REMOVE, Ref, use_pint
+    from .datatypes import Quantity, Coordinate, Uri, Bin, MARKER, NA, \
+            REMOVE, Ref, use_pint
     from .version import Version, VER_2_0, VER_3_0, LATEST_VER
     Q_ = Quantity
     __all__ = ['Grid', 'dump', 'parse', 'dump_scalar', 'parse_scalar',
             'MetadataObject', 'ureg',
-            'Coordinate', 'Uri', 'Bin', 'MARKER', 'REMOVE', 'Ref',
+            'Coordinate', 'Uri', 'Bin', 'MARKER', 'NA', 'REMOVE', 'Ref',
             'MODE_JSON', 'MODE_ZINC',
             'VER_2_0', 'VER_3_0', 'LATEST_VER', 'Version']
 except ImportError as e: # pragma: no cover

--- a/hszinc/datatypes.py
+++ b/hszinc/datatypes.py
@@ -378,12 +378,14 @@ class Bin(six.text_type):
             return NotImplemented
         return super(Bin, self).__eq__(other)
 
+
 class Singleton(object):
     def __copy__(self):
         return self
 
     def __deepcopy__(self, memo):
         return self
+
 
 class MarkerType(Singleton):
     """
@@ -393,6 +395,17 @@ class MarkerType(Singleton):
         return 'MARKER'
 
 MARKER = MarkerType()
+
+
+class NAType(Singleton):
+    """
+    A singleton class representing a NA.
+    """
+    def __repr__(self):
+        return 'NA'
+
+NA = NAType()
+
 
 class RemoveType(Singleton):
     """

--- a/hszinc/grid.py
+++ b/hszinc/grid.py
@@ -7,10 +7,13 @@
 
 from .metadata import MetadataObject
 from .sortabledict import SortableDict
-from collections import MutableSequence
+try:
+    import collections.abc as col
+except ImportError:
+    import collections as col
 from .version import Version, VER_3_0, VER_2_0
 
-class Grid(MutableSequence):
+class Grid(col.MutableSequence):
     '''
     A grid is basically a series of tabular records.  The grid has a header
     which describes some metadata about the grid and its columns.  This is

--- a/hszinc/grid.py
+++ b/hszinc/grid.py
@@ -5,6 +5,7 @@
 #
 # vim: set ts=4 sts=4 et tw=78 sw=4 si:
 
+from .datatypes import NA
 from .metadata import MetadataObject
 from .sortabledict import SortableDict
 try:
@@ -157,7 +158,8 @@ class Grid(col.MutableSequence):
         Detect the version used from the row content, or validate against
         the version if given.
         '''
-        if isinstance(val, list) \
+        if (val is NA) \
+                or isinstance(val, list) \
                 or isinstance(val, dict) \
                 or isinstance(val, SortableDict) \
                 or isinstance(val, Grid):

--- a/hszinc/jsondumper.py
+++ b/hszinc/jsondumper.py
@@ -75,6 +75,8 @@ def dump_scalar(scalar, version=LATEST_VER):
             return REMOVE3_STR
     elif isinstance(scalar, list):
         return dump_list(scalar, version=version)
+    elif isinstance(scalar, dict):
+        return dump_dict(scalar, version=version)
     elif isinstance(scalar, bool):
         return dump_bool(scalar, version=version)
     elif isinstance(scalar, Ref):
@@ -150,3 +152,9 @@ def dump_list(lst, version=LATEST_VER):
         raise ValueError('Project Haystack %s '\
                 'does not support lists' % version)
     return list(map(functools.partial(dump_scalar, version=version), lst))
+
+def dump_dict(dic, version=LATEST_VER):
+    if version < VER_3_0:
+        raise ValueError('Project Haystack %s '\
+                'does not support dict' % version)
+    return { k:dump_scalar(v, version=version) for (k,v) in dic.items()}

--- a/hszinc/jsondumper.py
+++ b/hszinc/jsondumper.py
@@ -8,9 +8,9 @@
 from __future__ import unicode_literals
 
 from .datatypes import Quantity, Coordinate, Ref, Bin, Uri, \
-        MARKER
+        MARKER, NA, REMOVE
 from .zoneinfo import timezone_name
-from .jsonparser import MARKER_STR
+from .jsonparser import MARKER_STR, NA_STR, REMOVE2_STR, REMOVE3_STR
 from .version import LATEST_VER, VER_3_0
 
 import datetime
@@ -63,6 +63,16 @@ def dump_scalar(scalar, version=LATEST_VER):
         return None
     elif scalar is MARKER:
         return MARKER_STR
+    elif scalar is NA:
+        if version < VER_3_0:
+            raise ValueError('Project Haystack %s '\
+                    'does not support NA' % version)
+        return NA_STR
+    elif scalar is REMOVE:
+        if version < VER_3_0:
+            return REMOVE2_STR
+        else:
+            return REMOVE3_STR
     elif isinstance(scalar, list):
         return dump_list(scalar, version=version)
     elif isinstance(scalar, bool):

--- a/hszinc/jsonparser.py
+++ b/hszinc/jsonparser.py
@@ -7,7 +7,7 @@
 
 from .grid import Grid
 from .datatypes import Quantity, Coordinate, Ref, Bin, Uri, \
-        MARKER, REMOVE, STR_SUB
+        MARKER, NA, REMOVE, STR_SUB
 from .zoneinfo import timezone
 from .version import LATEST_VER, Version, VER_3_0
 
@@ -24,6 +24,9 @@ GRID_SEP = re.compile(r'\n\n+')
 
 # Type regular expressions
 MARKER_STR  = 'm:'
+NA_STR      = 'z:'
+REMOVE2_STR = 'x:'
+REMOVE3_STR = '-:'
 NUMBER_RE   = re.compile(r'^n:(-?\d+(:?\.\d+)?(:?[eE][+\-]?\d+)?)(:? (.*))?$',
         flags=re.MULTILINE)
 REF_RE      = re.compile(r'^r:([a-zA-Z0-9_:\-.~]+)(:? (.*))?$',
@@ -97,6 +100,12 @@ def parse_scalar(scalar, version=LATEST_VER):
             scalar))
     elif scalar == MARKER_STR:
         return MARKER
+    elif scalar == NA_STR:
+        return NA
+    elif (scalar == REMOVE2_STR) or (scalar == REMOVE3_STR):
+        # Strictly speaking: x: is a HS 2.0 Remove, and -: is a 3.0 Remove
+        # but we'll treat both the same.
+        return REMOVE
     elif isinstance(scalar, bool):
         return scalar
     elif scalar == 'n:INF':

--- a/hszinc/jsonparser.py
+++ b/hszinc/jsonparser.py
@@ -84,8 +84,8 @@ def parse_scalar(scalar, version=LATEST_VER):
     # If we're given a string, decode the JSON data.
     if isinstance(scalar, six.text_type) and \
             (len(scalar) >= 2) and \
-            (scalar[0] in ('"','[','{')) and \
-            (scalar[-1] in ('"',']','}')):
+            (scalar[0] in ('"', '[', '{')) and \
+            (scalar[-1] in ('"', ']', '}')):
         scalar = json.loads(scalar)
 
     # Simple cases
@@ -94,10 +94,16 @@ def parse_scalar(scalar, version=LATEST_VER):
     elif isinstance(scalar, list):
         # We support this only in version 3.0 and up.
         if version < VER_3_0:
-            raise ValueError('Lists are not supported in Haystack version %s'\
-                    % version)
+            raise ValueError('Lists are not supported in Haystack version %s' \
+                             % version)
         return list(map(functools.partial(parse_scalar, version=version),
-            scalar))
+                        scalar))
+    elif isinstance(scalar, dict):
+        # We support this only in version 3.0 and up.
+        if version < VER_3_0:
+            raise ValueError('Dicts are not supported in Haystack version %s' \
+                             % version)
+        return {k: parse_scalar(v, version=version) for (k, v) in scalar.items()}
     elif scalar == MARKER_STR:
         return MARKER
     elif scalar == NA_STR:
@@ -160,14 +166,14 @@ def parse_scalar(scalar, version=LATEST_VER):
             sec = 0
             usec = 0
         elif '.' in second:
-            (whole_sec, frac_sec) = second.split('.',1)
+            (whole_sec, frac_sec) = second.split('.', 1)
             sec = int(whole_sec)
-            usec = int(frac_sec[:6].ljust(6,'0'))
+            usec = int(frac_sec[:6].ljust(6, '0'))
         else:
             sec = int(second)
             usec = 0
         return datetime.time(hour=int(hour), minute=int(minute),
-                second=sec, microsecond=usec)
+                             second=sec, microsecond=usec)
 
     # Is it a date/time?
     match = DATETIME_RE.match(scalar)
@@ -176,14 +182,14 @@ def parse_scalar(scalar, version=LATEST_VER):
         # Parse ISO8601 component
         isodate = iso8601.parse_date(matches[0])
         # Parse timezone
-        tzname  = matches[-1]
+        tzname = matches[-1]
         if tzname is None:
             return isodate  # No timezone given
         else:
             try:
                 tz = timezone(tzname)
                 return isodate.astimezone(tz)
-            except: # pragma: no cover
+            except:  # pragma: no cover
                 # Unlikely code path.
                 return isodate
 
@@ -200,6 +206,6 @@ def parse_scalar(scalar, version=LATEST_VER):
     # Is it a co-ordinate?
     match = COORD_RE.match(scalar)
     if match:
-        (lat,lng) = match.groups()
-        return Coordinate(float(lat),float(lng))
+        (lat, lng) = match.groups()
+        return Coordinate(float(lat), float(lng))
     return scalar

--- a/hszinc/parser.py
+++ b/hszinc/parser.py
@@ -6,9 +6,9 @@
 # vim: set ts=4 sts=4 et tw=78 sw=4 si:
 
 from .zincparser import parse_grid as parse_zinc_grid, \
-                        parse_scalar as parse_zinc_scalar
+    parse_scalar as parse_zinc_scalar
 from .jsonparser import parse_grid as parse_json_grid, \
-                        parse_scalar as parse_json_scalar
+    parse_scalar as parse_json_scalar
 import re
 import six
 import functools
@@ -22,6 +22,7 @@ GRID_SEP = re.compile(r'\n\n+')
 MODE_ZINC = 'text/zinc'
 MODE_JSON = 'application/json'
 
+
 def parse(grid_str, mode=MODE_ZINC, charset='utf-8'):
     '''
     Parse the given Zinc text and return the equivalent data.
@@ -34,22 +35,23 @@ def parse(grid_str, mode=MODE_ZINC, charset='utf-8'):
     # them up normally.  This will truncate the newline off the end of the last
     # row.
     _parse = functools.partial(parse_grid, mode=mode,
-            charset=charset)
+                               charset=charset)
     if mode == MODE_JSON:
         if isinstance(grid_str, six.string_types):
             grid_data = json.loads(grid_str)
         else:
             grid_data = grid_str
         if isinstance(grid_data, dict):
-            return _parse(grid_data)
+            return [_parse(grid_data)]
         else:
             return list(map(_parse, grid_data))
     else:
         return list(map(_parse, GRID_SEP.split(grid_str.rstrip())))
 
+
 def parse_grid(grid_str, mode=MODE_ZINC, charset='utf-8'):
     # Decode incoming text
-    if isinstance(grid_str, six.binary_type): # pragma: no cover
+    if isinstance(grid_str, six.binary_type):  # pragma: no cover
         # No coverage here, because it *should* be handled above unless the user
         # is pre-empting us by calling `parse_grid` directly.
         grid_str = grid_str.decode(encoding=charset)
@@ -58,8 +60,9 @@ def parse_grid(grid_str, mode=MODE_ZINC, charset='utf-8'):
         return parse_zinc_grid(grid_str)
     elif mode == MODE_JSON:
         return parse_json_grid(grid_str)
-    else: # pragma: no cover
+    else:  # pragma: no cover
         raise NotImplementedError('Format not implemented: %s' % mode)
+
 
 def parse_scalar(scalar, mode=MODE_ZINC, version=LATEST_VER, charset='utf-8'):
     # Decode version string
@@ -74,5 +77,5 @@ def parse_scalar(scalar, mode=MODE_ZINC, version=LATEST_VER, charset='utf-8'):
         return parse_zinc_scalar(scalar, version=version)
     elif mode == MODE_JSON:
         return parse_json_scalar(scalar, version=version)
-    else: # pragma: no cover
+    else:  # pragma: no cover
         raise NotImplementedError('Format not implemented: %s' % mode)

--- a/hszinc/parser.py
+++ b/hszinc/parser.py
@@ -19,8 +19,8 @@ from .version import Version, LATEST_VER
 
 GRID_SEP = re.compile(r'\n\n+')
 
-MODE_ZINC = 'zinc'
-MODE_JSON = 'json'
+MODE_ZINC = 'text/zinc'
+MODE_JSON = 'application/json'
 
 def parse(grid_str, mode=MODE_ZINC, charset='utf-8'):
     '''

--- a/hszinc/sortabledict.py
+++ b/hszinc/sortabledict.py
@@ -5,9 +5,12 @@
 #
 # vim: set ts=4 sts=4 et tw=78 sw=4 si:
 
-from collections import MutableMapping
+try:
+    import collections.abc as col
+except ImportError:
+    import collections as col
 
-class SortableDict(MutableMapping):
+class SortableDict(col.MutableMapping):
     """
     A dict-like object that permits value ordering/re-ordering.
     """

--- a/hszinc/zincdumper.py
+++ b/hszinc/zincdumper.py
@@ -8,7 +8,7 @@
 from __future__ import unicode_literals
 
 from .datatypes import Quantity, Coordinate, Ref, Bin, Uri, \
-        MARKER, REMOVE, STR_SUB
+        MARKER, NA, REMOVE, STR_SUB
 from .zoneinfo import timezone_name
 from .version import LATEST_VER, VER_3_0
 
@@ -83,6 +83,12 @@ def dump_row(grid, row):
 def dump_scalar(scalar, version=LATEST_VER):
     if scalar is None:
         return 'N'
+    elif scalar is NA:
+        if version < VER_3_0:
+            raise ValueError('Project Haystack version %s '\
+                            'does not support NA'\
+                            % version)
+        return 'NA'
     elif scalar is MARKER:
         return 'M'
     elif scalar is REMOVE:

--- a/hszinc/zincdumper.py
+++ b/hszinc/zincdumper.py
@@ -102,6 +102,13 @@ def dump_scalar(scalar, version=LATEST_VER):
         return '[%s]' % ','.join(map(
                 functools.partial(dump_scalar, version=version),
                 scalar))
+    elif isinstance(scalar, dict):
+        # Forbid version 2.0 and earlier.
+        if version < VER_3_0:
+            raise ValueError('Project Haystack version %s ' \
+                             'does not support dicts' \
+                             % version)
+        return '{'+' '.join([k+':'+dump_scalar(v, version=version) for (k, v) in scalar.items()])+'}'
     elif isinstance(scalar, bool):
         return dump_bool(scalar, version=version)
     elif isinstance(scalar, Ref):

--- a/hszinc/zincparser.py
+++ b/hszinc/zincparser.py
@@ -586,3 +586,4 @@ def parse_scalar(scalar_data, version):
     except:
         LOG.debug('Failing scalar data: %r (version %r)',
                 scalar_data, version)
+        raise

--- a/hszinc/zincparser.py
+++ b/hszinc/zincparser.py
@@ -16,7 +16,7 @@ import logging
 import re
 
 # Bring in special Project Haystack types and time zones
-from .datatypes import Quantity, Coordinate, Uri, Bin, MARKER, REMOVE, Ref
+from .datatypes import Quantity, Coordinate, Uri, Bin, MARKER, NA, REMOVE, Ref
 from .grid import Grid
 from .zoneinfo import timezone
 
@@ -391,8 +391,8 @@ hs_marker       = Literal('M').setParseAction(\
         lambda toks : [MARKER]).setName('marker')
 hs_null         = Literal('N').setParseAction(\
         lambda toks : [None]).setName('null')
-hs_na         = Literal('NA').setParseAction(\
-        lambda toks : [None]).setName('null')
+hs_na           = Literal('NA').setParseAction(\
+        lambda toks : [NA]).setName('na')
 # Lists, these will probably be in Haystack 4.0, so let's not
 # assume a version.  There are three cases:
 # - Empty list: [ {optional whitespace} ]

--- a/tests/test_acid.py
+++ b/tests/test_acid.py
@@ -15,20 +15,23 @@ import six
 
 STR_CHARSET = string.ascii_letters + string.digits + '\n\r\t\f\b'
 
+
 def gen_random_const():
-    return random.choice([True,False,None,hszinc.MARKER,hszinc.REMOVE])
+    return random.choice([True, False, None, hszinc.MARKER, hszinc.REMOVE])
+
 
 def gen_random_ref():
     # Generate a randomised reference.
-    name = gen_random_str(charset=\
-                string.ascii_letters + string.digits\
-                + '_:-.~')
-    if random.choice([True,False]):
+    name = gen_random_str(charset= \
+                              string.ascii_letters + string.digits \
+                              + '_:-.~')
+    if random.choice([True, False]):
         value = gen_random_str()
     else:
         value = None
 
     return hszinc.Ref(name, value)
+
 
 def gen_random_bin():
     # Generate a randomized binary
@@ -42,26 +45,31 @@ def gen_random_bin():
         'image/jpeg',
     ]))
 
+
 def gen_random_uri():
     return hszinc.Uri(gen_random_str())
 
-def gen_random_str(min_length=1, max_length=20,charset=STR_CHARSET):
+
+def gen_random_str(min_length=1, max_length=20, charset=STR_CHARSET):
     # Generate a random 20-character string
     return ''.join([random.choice(charset) for c in range(0,
-        random.randint(min_length, max_length))])
+                                                          random.randint(min_length, max_length))])
+
 
 def gen_random_date():
     # This might generate an invalid date, we keep trying until we get one.
     while True:
         try:
-            return datetime.date(random.randint(1,3000),
-                                random.randint(1,12), random.randint(1,31))
+            return datetime.date(random.randint(1, 3000),
+                                 random.randint(1, 12), random.randint(1, 31))
         except ValueError:
             pass
 
+
 def gen_random_time():
-    return datetime.time(random.randint(0,23), random.randint(0,59),
-                        random.randint(0,59), random.randint(0,999999))
+    return datetime.time(random.randint(0, 23), random.randint(0, 59),
+                         random.randint(0, 59), random.randint(0, 999999))
+
 
 def gen_random_date_time():
     # Pick a random timezone
@@ -70,17 +78,21 @@ def gen_random_date_time():
     return tz.localize(datetime.datetime.combine(
         gen_random_date(), gen_random_time()))
 
-def gen_random_coordinate():
-    return hszinc.Coordinate(\
-            gen_random_num(360)-180.0,
-            gen_random_num(360)-180.0)
 
-def gen_random_num(scale=1000,digits=2):
-    return round(random.random()*scale, digits)
+def gen_random_coordinate():
+    return hszinc.Coordinate( \
+        gen_random_num(360) - 180.0,
+        gen_random_num(360) - 180.0)
+
+
+def gen_random_num(scale=1000, digits=2):
+    return round(random.random() * scale, digits)
+
 
 def gen_random_quantity():
     return hszinc.Quantity(gen_random_num(),
-            to_pint('percent'))
+                           to_pint('percent'))
+
 
 RANDOM_TYPES = [
     gen_random_const, gen_random_ref, gen_random_bin, gen_random_uri,
@@ -88,41 +100,46 @@ RANDOM_TYPES = [
     gen_random_coordinate, gen_random_num, gen_random_quantity
 ]
 
+
 def gen_random_scalar():
     return random.choice(RANDOM_TYPES)()
+
 
 def gen_random_name(existing=None):
     while True:
         meta = random.choice(string.ascii_lowercase) \
-                + gen_random_str(min_length=0, max_length=7, \
-                    charset=string.ascii_letters + string.digits)
+               + gen_random_str(min_length=0, max_length=7, \
+                                charset=string.ascii_letters + string.digits)
         if (existing is None) or (meta not in existing):
             return meta
+
 
 def gen_random_meta():
     meta = hszinc.MetadataObject()
     names = set()
-    for n in range(0, random.randint(1,5)):
+    for n in range(0, random.randint(1, 5)):
         name = gen_random_name(existing=names)
         value = gen_random_scalar()
         meta[name] = value
     return meta
 
+
 def dump_grid(g):
-    print ('Version: %s' % g.version)
-    print ('Metadata:')
+    print('Version: %s' % g.version)
+    print('Metadata:')
     for k, v in g.metadata.items():
-        print ('   %s = %r' % (k, v))
-    print ('Columns:')
+        print('   %s = %r' % (k, v))
+    print('Columns:')
     for c, meta in g.column.items():
-        print ('   %s:' % c)
+        print('   %s:' % c)
         for k, v in g.column[c].items():
-            print ('      %s = %r' % (k, v))
-    print ('Rows:')
+            print('      %s = %r' % (k, v))
+    print('Rows:')
     for row in g:
-        print ('---')
+        print('---')
         for c, v in row.items():
-            print ('  %s = %r' % (c, v))
+            print('  %s = %r' % (c, v))
+
 
 def approx_check(v1, v2):
     # Check types match
@@ -147,24 +164,25 @@ def approx_check(v1, v2):
     else:
         assert v1 == v2, '%r != %r' % (v1, v2)
 
+
 def try_dump_parse():
     # Generate a randomised grid of values and try parsing it back.
     ref_grid = hszinc.Grid()
     ref_grid.metadata.extend(gen_random_meta())
 
     # Randomised columns
-    for n in range(0, random.randint(1,5)):
+    for n in range(0, random.randint(1, 5)):
         col_name = gen_random_name(existing=ref_grid.column)
-        if random.choice([True,False]):
+        if random.choice([True, False]):
             ref_grid.column[col_name] = gen_random_meta()
         else:
             ref_grid.column[col_name] = {}
 
     # Randomised rows
-    for n in range(0, random.randint(0,20)):
+    for n in range(0, random.randint(0, 20)):
         row = {}
         for c in ref_grid.column.keys():
-            if random.choice([True,False]):
+            if random.choice([True, False]):
                 row[c] = gen_random_scalar()
         ref_grid.append(row)
 
@@ -173,7 +191,7 @@ def try_dump_parse():
         grid_str = hszinc.dump(ref_grid)
     except:
         # Dump some detail about the grid
-        print ('Failed to dump grid.')
+        print('Failed to dump grid.')
         dump_grid(ref_grid)
         raise
 
@@ -181,10 +199,10 @@ def try_dump_parse():
     try:
         grid_list = hszinc.parse(grid_str)
     except:
-        print ('Failed to parse dumped grid')
+        print('Failed to parse dumped grid')
         dump_grid(ref_grid)
-        print ('--- Parsed string ---')
-        print (grid_str)
+        print('--- Parsed string ---')
+        print(grid_str)
         raise
 
     assert len(grid_list) == 1
@@ -193,47 +211,47 @@ def try_dump_parse():
     # Check metadata matches
     try:
         assert list(ref_grid.metadata.keys()) \
-                == list(parsed_grid.metadata.keys())
+               == list(parsed_grid.metadata.keys())
         for key in ref_grid.metadata.keys():
             approx_check(ref_grid.metadata[key], parsed_grid.metadata[key])
     except:
-        print ('Mismatch in metadata')
-        print ('Reference grid')
+        print('Mismatch in metadata')
+        print('Reference grid')
         dump_grid(ref_grid)
-        print ('Parsed grid')
+        print('Parsed grid')
         dump_grid(parsed_grid)
         raise
 
     try:
         # Check column matches
         assert list(ref_grid.column.keys()) \
-                == list(parsed_grid.column.keys())
+               == list(parsed_grid.column.keys())
     except:
-        print ('Mismatch in column')
-        print ('Reference grid')
+        print('Mismatch in column')
+        print('Reference grid')
         dump_grid(ref_grid)
-        print ('Parsed grid')
+        print('Parsed grid')
         dump_grid(parsed_grid)
         raise
     for col in ref_grid.column.keys():
         try:
             for key in ref_grid.column[col].keys():
                 approx_check(ref_grid.column[col][key], \
-                        parsed_grid.column[col][key])
+                             parsed_grid.column[col][key])
         except:
-            print ('Mismatch in metadata for column %s' % col)
-            print ('Reference: %r' % ref_grid.column[col])
-            print ('Parsed:    %r' % parsed_grid.column[col])
+            print('Mismatch in metadata for column %s' % col)
+            print('Reference: %r' % ref_grid.column[col])
+            print('Parsed:    %r' % parsed_grid.column[col])
             raise
 
     try:
         # Check row matches
         assert len(ref_grid) == len(parsed_grid)
     except:
-        print ('Mismatch in row count')
-        print ('Reference grid')
+        print('Mismatch in row count')
+        print('Reference grid')
         dump_grid(ref_grid)
-        print ('Parsed grid')
+        print('Parsed grid')
         dump_grid(parsed_grid)
 
     for (ref_row, parsed_row) in zip(ref_grid, parsed_grid):
@@ -241,12 +259,13 @@ def try_dump_parse():
             for col in ref_grid.column.keys():
                 approx_check(ref_row.get(col), parsed_row.get(col))
         except:
-            print ('Mismatch in row')
-            print ('Reference:')
-            print (ref_row)
-            print ('Parsed:')
-            print (parsed_row)
+            print('Mismatch in row')
+            print('Reference:')
+            print(ref_row)
+            print('Parsed:')
+            print(parsed_row)
             raise
+
 
 def test_loopback():
     for trial in range(0, 10):

--- a/tests/test_dumper.py
+++ b/tests/test_dumper.py
@@ -322,6 +322,10 @@ def test_data_types_json():
             'value': hszinc.MARKER,
         },
         {
+            'comment': 'A remove (2.0 version)',
+            'value': hszinc.REMOVE,
+        },
+        {
             'comment': 'A boolean, indicating False',
             'value': False,
         },
@@ -394,6 +398,8 @@ def test_data_types_json():
                     'value': None},
                 {   'comment': 's:A marker',
                     'value': 'm:'},
+                {   'comment': 's:A remove (2.0 version)',
+                    'value': 'x:'},
                 {   'comment': 's:A boolean, indicating False',
                     'value': False},
                 {   'comment': 's:A boolean, indicating True',

--- a/tests/test_dumper.py
+++ b/tests/test_dumper.py
@@ -267,6 +267,10 @@ def test_data_types_v3():
     grid.column['value'] = {}
     grid.extend([
         {
+            'comment': 'A NA',
+            'value': hszinc.NA,
+        },
+        {
             'comment': 'An empty list',
             'value': [],
         },
@@ -294,6 +298,7 @@ def test_data_types_v3():
     grid_str = hszinc.dump(grid)
     ref_str = '''ver:"3.0"
 comment,value
+"A NA",NA
 "An empty list",[]
 "A null value in a list",[N]
 "A marker in a list",[M]
@@ -429,6 +434,14 @@ def test_data_types_json_v3():
     grid.column['value'] = {}
     grid.extend([
         {
+            'comment': 'A Remove (3.0 version)',
+            'value': hszinc.REMOVE,
+        },
+        {
+            'comment': 'A NA',
+            'value': hszinc.NA,
+        },
+        {
             'comment': 'An empty list',
             'value': [],
         },
@@ -463,6 +476,14 @@ def test_data_types_json_v3():
                 {'name': 'value'},
             ],
             'rows': [
+                {
+                    'comment': 's:A Remove (3.0 version)',
+                    'value': '-:'
+                },
+                {
+                    'comment': 's:A NA',
+                    'value': 'z:'
+                },
                 {
                     'comment':"s:An empty list",
                     'value':[]

--- a/tests/test_dumper.py
+++ b/tests/test_dumper.py
@@ -10,15 +10,16 @@ import pytz
 import json
 
 from .test_parser import SIMPLE_EXAMPLE, SIMPLE_EXAMPLE_JSON, \
-        METADATA_EXAMPLE_JSON
+    METADATA_EXAMPLE_JSON
 
 # The metadata example is a little different, as we generate the grid without
 # spaces around the commas.
-METADATA_EXAMPLE='''ver:"2.0" database:"test" dis:"Site Energy Summary"
+METADATA_EXAMPLE = '''ver:"2.0" database:"test" dis:"Site Energy Summary"
 siteName dis:"Sites",val dis:"Value" unit:"kW"
 "Site 1",356.214kW
 "Site 2",463.028kW
 '''
+
 
 def make_simple_grid(version=hszinc.VER_2_0):
     grid = hszinc.Grid(version=version)
@@ -27,24 +28,27 @@ def make_simple_grid(version=hszinc.VER_2_0):
     grid.extend([
         {
             'firstName': 'Jack',
-            'bday': datetime.date(1973,7,23),
+            'bday': datetime.date(1973, 7, 23),
         },
         {
             'firstName': 'Jill',
-            'bday': datetime.date(1975,11,15),
+            'bday': datetime.date(1975, 11, 15),
         },
     ])
     return grid
+
 
 def test_simple():
     grid = make_simple_grid()
     grid_str = hszinc.dump(grid)
     assert grid_str == SIMPLE_EXAMPLE
 
+
 def test_simple_json():
     grid = make_simple_grid()
     grid_json = json.loads(hszinc.dump(grid, mode=hszinc.MODE_JSON))
     assert grid_json == SIMPLE_EXAMPLE_JSON
+
 
 def make_metadata_grid(version=hszinc.VER_2_0):
     grid = hszinc.Grid(version=version)
@@ -57,30 +61,34 @@ def make_metadata_grid(version=hszinc.VER_2_0):
     grid.extend([
         {
             'siteName': 'Site 1',
-            'val': hszinc.Quantity(356.214,'kW'),
+            'val': hszinc.Quantity(356.214, 'kW'),
         },
         {
             'siteName': 'Site 2',
-            'val': hszinc.Quantity(463.028,'kW'),
+            'val': hszinc.Quantity(463.028, 'kW'),
         },
     ])
     return grid
+
 
 def test_metadata():
     grid = make_metadata_grid()
     grid_str = hszinc.dump(grid)
     assert grid_str == METADATA_EXAMPLE
 
+
 def test_metadata_json():
     grid = make_metadata_grid()
     grid_json = json.loads(hszinc.dump(grid, mode=hszinc.MODE_JSON))
     assert grid_json == METADATA_EXAMPLE_JSON
+
 
 def test_multi_grid():
     grids = [make_simple_grid(), make_metadata_grid()]
     grid_str = hszinc.dump(grids)
 
     assert grid_str == '\n'.join([SIMPLE_EXAMPLE, METADATA_EXAMPLE])
+
 
 def test_multi_grid_json():
     grids = [make_simple_grid(), make_metadata_grid()]
@@ -89,15 +97,17 @@ def test_multi_grid_json():
     assert grid_json[0] == SIMPLE_EXAMPLE_JSON
     assert grid_json[1] == METADATA_EXAMPLE_JSON
 
+
 def make_grid_meta(version=hszinc.VER_2_0):
     grid = hszinc.Grid(version=version)
     grid.metadata['aString'] = 'aValue'
     grid.metadata['aNumber'] = 3.14159
     grid.metadata['aNull'] = None
     grid.metadata['aMarker'] = hszinc.MARKER
-    grid.metadata['aQuantity'] = hszinc.Quantity(123,'Hz')
+    grid.metadata['aQuantity'] = hszinc.Quantity(123, 'Hz')
     grid.column['empty'] = {}
     return grid
+
 
 def test_grid_meta():
     grid_str = hszinc.dump(make_grid_meta())
@@ -105,23 +115,25 @@ def test_grid_meta():
 empty
 '''
 
+
 def test_grid_meta_json():
     grid_json = json.loads(hszinc.dump(make_grid_meta(),
-        mode=hszinc.MODE_JSON))
+                                       mode=hszinc.MODE_JSON))
     assert grid_json == {
-            'meta': {
-                'ver': '2.0',
-                'aString': 's:aValue',
-                'aNumber': 'n:3.141590',
-                'aNull': None,
-                'aMarker': 'm:',
-                'aQuantity': 'n:123.000000 Hz',
-            },
-            'cols': [
-                {'name': 'empty'},
-            ],
-            'rows': [],
+        'meta': {
+            'ver': '2.0',
+            'aString': 's:aValue',
+            'aNumber': 'n:3.141590',
+            'aNull': None,
+            'aMarker': 'm:',
+            'aQuantity': 'n:123.000000 Hz',
+        },
+        'cols': [
+            {'name': 'empty'},
+        ],
+        'rows': [],
     }
+
 
 def make_col_meta(version=hszinc.VER_2_0):
     grid = hszinc.Grid(version=version)
@@ -130,9 +142,10 @@ def make_col_meta(version=hszinc.VER_2_0):
     col_meta['aNumber'] = 3.14159
     col_meta['aNull'] = None
     col_meta['aMarker'] = hszinc.MARKER
-    col_meta['aQuantity'] = hszinc.Quantity(123,'Hz')
+    col_meta['aQuantity'] = hszinc.Quantity(123, 'Hz')
     grid.column['empty'] = col_meta
     return grid
+
 
 def test_col_meta():
     grid_str = hszinc.dump(make_col_meta())
@@ -140,24 +153,26 @@ def test_col_meta():
 empty aString:"aValue" aNumber:3.14159 aNull:N aMarker aQuantity:123Hz
 '''
 
+
 def test_col_meta_json():
     grid_json = json.loads(hszinc.dump(make_col_meta(),
-        mode=hszinc.MODE_JSON))
+                                       mode=hszinc.MODE_JSON))
     assert grid_json == {
-            'meta': {
-                'ver': '2.0',
-            },
-            'cols': [
-                {   'name': 'empty',
-                    'aString': 's:aValue',
-                    'aNumber': 'n:3.141590',
-                    'aNull': None,
-                    'aMarker': 'm:',
-                    'aQuantity': 'n:123.000000 Hz',
-                },
-            ],
-            'rows': [],
+        'meta': {
+            'ver': '2.0',
+        },
+        'cols': [
+            {'name': 'empty',
+             'aString': 's:aValue',
+             'aNumber': 'n:3.141590',
+             'aNull': None,
+             'aMarker': 'm:',
+             'aQuantity': 'n:123.000000 Hz',
+             },
+        ],
+        'rows': [],
     }
+
 
 def test_data_types_v2():
     grid = hszinc.Grid(version=hszinc.VER_2_0)
@@ -198,15 +213,15 @@ def test_data_types_v2():
         },
         {
             'comment': 'A quantity',
-            'value': hszinc.Quantity(500,'miles'),
+            'value': hszinc.Quantity(500, 'miles'),
         },
         {
             'comment': 'A quantity without unit',
-            'value': hszinc.Quantity(500,None),
+            'value': hszinc.Quantity(500, None),
         },
         {
             'comment': 'A coordinate',
-            'value': hszinc.Coordinate(-27.4725,153.003),
+            'value': hszinc.Coordinate(-27.4725, 153.003),
         },
         {
             'comment': 'A URI',
@@ -214,28 +229,28 @@ def test_data_types_v2():
         },
         {
             'comment': 'A string',
-            'value':    u'This is a test\n'\
-                        u'Line two of test\n'\
-                        u'\tIndented with "quotes", \\backslashes\\ and '\
-                        u'Unicode characters: \u1234\u5678 and a $ dollar sign',
+            'value': u'This is a test\n' \
+                     u'Line two of test\n' \
+                     u'\tIndented with "quotes", \\backslashes\\ and ' \
+                     u'Unicode characters: \u1234\u5678 and a $ dollar sign',
         },
         {
             'comment': 'A date',
-            'value': datetime.date(2016,1,13),
+            'value': datetime.date(2016, 1, 13),
         },
         {
             'comment': 'A time',
-            'value': datetime.time(7,51,43,microsecond=12345),
+            'value': datetime.time(7, 51, 43, microsecond=12345),
         },
         {
             'comment': 'A timestamp (non-UTC)',
-            'value': pytz.timezone('Europe/Berlin').localize(\
-                    datetime.datetime(2016,1,13,7,51,42,12345)),
+            'value': pytz.timezone('Europe/Berlin').localize( \
+                datetime.datetime(2016, 1, 13, 7, 51, 42, 12345)),
         },
         {
             'comment': 'A timestamp (UTC)',
-            'value': pytz.timezone('UTC').localize(\
-                    datetime.datetime(2016,1,13,7,51,42,12345)),
+            'value': pytz.timezone('UTC').localize( \
+                datetime.datetime(2016, 1, 13, 7, 51, 42, 12345)),
         },
     ])
     grid_str = hszinc.dump(grid)
@@ -260,6 +275,7 @@ comment,value
 "A timestamp (UTC)",2016-01-13T07:51:42.012345+00:00 UTC
 '''
     assert grid_str == ref_str
+
 
 def test_data_types_v3():
     grid = hszinc.Grid(version=hszinc.VER_3_0)
@@ -292,7 +308,7 @@ def test_data_types_v3():
         },
         {
             'comment': 'A quantity',
-            'value': [hszinc.Quantity(500,'miles')],
+            'value': [hszinc.Quantity(500, 'miles')],
         },
     ])
     grid_str = hszinc.dump(grid)
@@ -307,6 +323,7 @@ comment,value
 "A quantity",[500miles]
 '''
     assert grid_str == ref_str
+
 
 def test_data_types_json():
     grid = hszinc.Grid(version=hszinc.VER_2_0)
@@ -347,15 +364,15 @@ def test_data_types_json():
         },
         {
             'comment': 'A quantity',
-            'value': hszinc.Quantity(500,'miles'),
+            'value': hszinc.Quantity(500, 'miles'),
         },
         {
             'comment': 'A quantity without unit',
-            'value': hszinc.Quantity(500,None),
+            'value': hszinc.Quantity(500, None),
         },
         {
             'comment': 'A coordinate',
-            'value': hszinc.Coordinate(-27.4725,153.003),
+            'value': hszinc.Coordinate(-27.4725, 153.003),
         },
         {
             'comment': 'A URI',
@@ -363,27 +380,27 @@ def test_data_types_json():
         },
         {
             'comment': 'A string',
-            'value':    'This is a test\n'\
-                        'Line two of test\n'\
-                        '\tIndented with "quotes" and \\backslashes\\',
+            'value': 'This is a test\n' \
+                     'Line two of test\n' \
+                     '\tIndented with "quotes" and \\backslashes\\',
         },
         {
             'comment': 'A date',
-            'value': datetime.date(2016,1,13),
+            'value': datetime.date(2016, 1, 13),
         },
         {
             'comment': 'A time',
-            'value': datetime.time(7,51,43,microsecond=12345),
+            'value': datetime.time(7, 51, 43, microsecond=12345),
         },
         {
             'comment': 'A timestamp (non-UTC)',
-            'value': pytz.timezone('Europe/Berlin').localize(\
-                    datetime.datetime(2016,1,13,7,51,42,12345)),
+            'value': pytz.timezone('Europe/Berlin').localize( \
+                datetime.datetime(2016, 1, 13, 7, 51, 42, 12345)),
         },
         {
             'comment': 'A timestamp (UTC)',
-            'value': pytz.timezone('UTC').localize(\
-                    datetime.datetime(2016,1,13,7,51,42,12345)),
+            'value': pytz.timezone('UTC').localize( \
+                datetime.datetime(2016, 1, 13, 7, 51, 42, 12345)),
         },
     ])
     grid_json = json.loads(hszinc.dump(grid, mode=hszinc.MODE_JSON))
@@ -434,7 +451,8 @@ def test_data_types_json():
             ],
     }
 
-def test_data_types_json_v3():
+
+def test_list_types_json_v3():
     grid = hszinc.Grid(version=hszinc.VER_3_0)
     grid.column['comment'] = {}
     grid.column['value'] = {}
@@ -469,54 +487,141 @@ def test_data_types_json_v3():
         },
         {
             'comment': 'A quantity',
-            'value': [hszinc.Quantity(500,'miles')],
+            'value': [hszinc.Quantity(500, 'miles')],
         },
     ])
     grid_json = json.loads(hszinc.dump(grid, mode=hszinc.MODE_JSON))
     assert grid_json == {
-            'meta': {
-                'ver': '3.0'
+        'meta': {
+            'ver': '3.0'
+        },
+        'cols': [
+            {'name': 'comment'},
+            {'name': 'value'},
+        ],
+        'rows': [
+            {
+                'comment': 's:A Remove (3.0 version)',
+                'value': '-:',
             },
-            'cols': [
-                {'name': 'comment'},
-                {'name': 'value'},
-            ],
-            'rows': [
-                {
-                    'comment': 's:A Remove (3.0 version)',
-                    'value': '-:'
-                },
-                {
-                    'comment': 's:A NA',
-                    'value': 'z:'
-                },
-                {
-                    'comment':"s:An empty list",
-                    'value':[]
-                },
-                {
-                    'comment':"s:A null value in a list",
-                    'value': [None]
-                },
-                {
-                    'comment':"s:A marker in a list",
-                    'value': ['m:']
-                },
-                {
-                    'comment':"s:Booleans",
-                    'value': [True, False]
-                },
-                {
-                    'comment':"s:References",
-                    'value': ['r:a-ref' , 'r:a-ref a value']
-                },
-                {
-                    'comment':"s:A quantity",
-                    'value': ['n:500.000000 miles'] # Python is more precise
-                                                    # than The Proclaimers
-                }
-            ]
+            {
+                'comment': 's:A NA',
+                'value': 'z:',
+            },
+            {
+                'comment': "s:An empty list",
+                'value': []
+            },
+            {
+                'comment': "s:A null value in a list",
+                'value': [None]
+            },
+            {
+                'comment': "s:A marker in a list",
+                'value': ['m:']
+            },
+            {
+                'comment': "s:Booleans",
+                'value': [True, False]
+            },
+            {
+                'comment': "s:References",
+                'value': ['r:a-ref', 'r:a-ref a value']
+            },
+            {
+                'comment': "s:A quantity",
+                'value': ['n:500.000000 miles']  # Python is more precise
+                # than The Proclaimers
+            }
+        ]
     }
+
+
+def test_dict_types_json_v3():
+    grid = hszinc.Grid(version=hszinc.VER_3_0)
+    grid.column['comment'] = {}
+    grid.column['value'] = {}
+    grid.extend([
+        {
+            'comment': 'An empty dict',
+            'value': {},
+        },
+        {
+            'comment': 'A marker in a dict',
+            'value': {"marker": hszinc.MARKER},
+        },
+        {
+            'comment': 'A references in a dict',
+            'value': {"ref": hszinc.Ref('a-ref'), "ref2": hszinc.Ref('a-ref', 'a value')},
+        },
+        {
+            'comment': 'A quantity in a dict',
+            'value': {"quantity": hszinc.Quantity(500, 'miles')},
+        },
+    ])
+    grid_json = json.loads(hszinc.dump(grid, mode=hszinc.MODE_JSON))
+    assert grid_json == {
+        'meta': {
+            'ver': '3.0'
+        },
+        'cols': [
+            {'name': 'comment'},
+            {'name': 'value'},
+        ],
+        'rows': [
+            {
+                'comment': "s:An empty dict",
+                'value': {}
+            },
+            {
+                'comment': "s:A marker in a dict",
+                'value': {'marker': 'm:'}
+            },
+            {
+                'comment': "s:A references in a dict",
+                'value': {'ref': 'r:a-ref', 'ref2': 'r:a-ref a value'}
+            },
+            {
+                'comment': "s:A quantity in a dict",
+                'value': {"quantity": 'n:500.000000 miles'}
+            }
+        ]
+    }
+
+
+def test_dict_types_zinc_v3():
+    grid = hszinc.Grid(version=hszinc.VER_3_0)
+    grid.column['comment'] = {}
+    grid.column['value'] = {}
+    grid.extend([
+        {
+            'comment': 'An empty dict',
+            'value': {},
+        },
+        {
+            'comment': 'A marker in a dict',
+            'value': {"marker": hszinc.MARKER},
+        },
+        {
+            'comment': 'A references in a dict',
+            'value': {"ref": hszinc.Ref('a-ref'), "ref2": hszinc.Ref('a-ref', 'a value')},
+        },
+        {
+            'comment': 'A quantity in a dict',
+            'value': {"quantity": hszinc.Quantity(500, 'miles')},
+        },
+    ])
+    grid_str = hszinc.dump(grid, mode=hszinc.MODE_ZINC)
+    assert grid_str == ("ver:\"3.0\"\n"
+        "comment,value\n"
+        "\"An empty dict\",{}\n"
+        "\"A marker in a dict\",{marker:M}\n"
+        "\"A references in a dict\",{"+
+                    " ".join([str(k)+":"+str(v) for k,v in { "ref":"@a-ref", "ref2":"@a-ref" }.items()])\
+                            .replace("ref2:@a-ref","ref2:@a-ref \"a value\"") +\
+                            "}\n"
+        "\"A quantity in a dict\",{quantity:500miles}\n")
+
 
 def test_list_zinc_v2():
     try:
@@ -534,6 +639,24 @@ def test_list_zinc_v2():
     except ValueError:
         pass
 
+
+def test_dict_zinc_v2():
+    try:
+        grid = hszinc.Grid(version=hszinc.VER_2_0)
+        grid.column['comment'] = {}
+        grid.column['value'] = {}
+        grid.extend([
+            {
+                'comment': 'An empty dict',
+                'value': {},
+            }
+        ])
+        hszinc.dump(grid, mode=hszinc.MODE_ZINC)
+        assert False, 'Project Haystack 2.0 doesn\'t support dict'
+    except ValueError:
+        pass
+
+
 def test_list_json_v2():
     try:
         grid = hszinc.Grid(version=hszinc.VER_2_0)
@@ -550,17 +673,36 @@ def test_list_json_v2():
     except ValueError:
         pass
 
+
+def test_dict_json_v2():
+    try:
+        grid = hszinc.Grid(version=hszinc.VER_2_0)
+        grid.column['comment'] = {}
+        grid.column['value'] = {}
+        grid.extend([
+            {
+                'comment': 'An empty dict',
+                'value': {},
+            }
+        ])
+        hszinc.dump(grid, mode=hszinc.MODE_JSON)
+        assert False, 'Project Haystack 2.0 doesn\'t support dict'
+    except ValueError:
+        pass
+
+
 def test_scalar_zinc():
     # No need to be exhaustive, the underlying function is tested heavily by
     # the grid dump tests.
     assert hszinc.dump_scalar(hszinc.Ref('areference', 'a display name'),
-            mode=hszinc.MODE_ZINC) == '@areference "a display name"'
+                              mode=hszinc.MODE_ZINC) == '@areference "a display name"'
+
 
 def test_scalar_list_zinc_ver():
     # Test that versions are respected.
     try:
         hszinc.dump_scalar(["a list is not allowed in v2.0"],
-                mode=hszinc.MODE_ZINC, version=hszinc.VER_2_0)
+                           mode=hszinc.MODE_ZINC, version=hszinc.VER_2_0)
         assert False, 'Serialised a list in Haystack v2.0'
     except ValueError:
         pass
@@ -578,13 +720,14 @@ def test_scalar_json():
     # No need to be exhaustive, the underlying function is tested heavily by
     # the grid dump tests.
     assert hszinc.dump_scalar(hszinc.Ref('areference', 'a display name'),
-            mode=hszinc.MODE_JSON) == 'r:areference a display name'
+                              mode=hszinc.MODE_JSON) == 'r:areference a display name'
+
 
 def test_scalar_list_json_ver():
     # Test that versions are respected.
     try:
         hszinc.dump_scalar(["a list is not allowed in v2.0"],
-                mode=hszinc.MODE_JSON, version=hszinc.VER_2_0)
+                           mode=hszinc.MODE_JSON, version=hszinc.VER_2_0)
         assert False, 'Serialised a list in Haystack v2.0'
     except ValueError:
         pass

--- a/tests/test_dumper.py
+++ b/tests/test_dumper.py
@@ -550,12 +550,21 @@ def test_scalar_zinc():
     assert hszinc.dump_scalar(hszinc.Ref('areference', 'a display name'),
             mode=hszinc.MODE_ZINC) == '@areference "a display name"'
 
-def test_scalar_zinc_ver():
+def test_scalar_list_zinc_ver():
     # Test that versions are respected.
     try:
         hszinc.dump_scalar(["a list is not allowed in v2.0"],
                 mode=hszinc.MODE_ZINC, version=hszinc.VER_2_0)
         assert False, 'Serialised a list in Haystack v2.0'
+    except ValueError:
+        pass
+
+def test_scalar_list_na_ver():
+    # Test that versions are respected.
+    try:
+        hszinc.dump_scalar(hszinc.NA,
+                mode=hszinc.MODE_ZINC, version=hszinc.VER_2_0)
+        assert False, 'Serialised a NA in Haystack v2.0'
     except ValueError:
         pass
 
@@ -565,11 +574,20 @@ def test_scalar_json():
     assert hszinc.dump_scalar(hszinc.Ref('areference', 'a display name'),
             mode=hszinc.MODE_JSON) == 'r:areference a display name'
 
-def test_scalar_json_ver():
+def test_scalar_list_json_ver():
     # Test that versions are respected.
     try:
         hszinc.dump_scalar(["a list is not allowed in v2.0"],
                 mode=hszinc.MODE_JSON, version=hszinc.VER_2_0)
         assert False, 'Serialised a list in Haystack v2.0'
+    except ValueError:
+        pass
+
+def test_scalar_na_json_ver():
+    # Test that versions are respected.
+    try:
+        hszinc.dump_scalar(hszinc.NA,
+                mode=hszinc.MODE_JSON, version=hszinc.VER_2_0)
+        assert False, 'Serialised a NA in Haystack v2.0'
     except ValueError:
         pass

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1689,3 +1689,13 @@ c1, c2
     except hszinc.zincparser.ZincParseException as zpe:
         assert zpe.line == 4
         assert zpe.col == 4
+
+def test_malformed_zinc_scalar():
+    # This should always raise an error after logging
+    try:
+        hszinc.parse_scalar(12341234, mode=hszinc.MODE_ZINC)
+        assert False, 'Should have failed'
+    except AssertionError:
+        raise
+    except:
+        pass

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -11,10 +11,17 @@ from nose.tools import assert_is
 import warnings
 import hszinc
 import datetime
-import math
-import pytz
 import json
+import math
 import os
+import warnings
+
+import pytz
+
+import hszinc
+from hszinc import MARKER
+from hszinc.zincparser import hs_row
+from .pint_enable import _enable_pint
 
 # These are examples taken from http://project-haystack.org/doc/Zinc
 
@@ -491,7 +498,7 @@ def _check_marker_in_row_json(pint_en):
             {'str': 'Marker',       'marker':'m:'},
         ],
     }, mode=hszinc.MODE_JSON)
-    assert len(grid_list) == 1
+    assert(len(grid_list) == 1)
     grid = grid_list[0]
     assert grid[0]['marker'] is None
     assert grid[1]['marker'] is hszinc.MARKER

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -67,8 +67,10 @@ def test_simple_json_str():
 
 def _check_simple_json_str(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse(json.dumps(SIMPLE_EXAMPLE_JSON),
+    grid_list = hszinc.parse(json.dumps(SIMPLE_EXAMPLE_JSON),
             mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     check_simple(grid)
 
 def test_wc1382_unicode_str():
@@ -245,7 +247,9 @@ def test_metadata_json():
 
 def _check_metadata_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse(METADATA_EXAMPLE_JSON, mode=hszinc.MODE_JSON)
+    grid_list = hszinc.parse(METADATA_EXAMPLE_JSON, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     check_metadata(grid, force_metadata_order=False)
 
 def check_metadata(grid,force_metadata_order=True):
@@ -344,7 +348,9 @@ def test_null_json():
 
 def _check_null_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse(NULL_EXAMPLE_JSON, mode=hszinc.MODE_JSON)
+    grid_list = hszinc.parse(NULL_EXAMPLE_JSON, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     check_null(grid)
 
 NA_EXAMPLE='''ver:"3.0"
@@ -382,7 +388,9 @@ def test_na_json():
 
 def _check_na_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse(NA_EXAMPLE_JSON, mode=hszinc.MODE_JSON)
+    grid_list = hszinc.parse(NA_EXAMPLE_JSON, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     check_na(grid)
 
 REMOVE_EXAMPLE='''ver:"3.0"
@@ -438,12 +446,16 @@ def test_remove_json_v3():
 
 def _check_remove_json_v2(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse(REMOVE_EXAMPLE_JSON_V2, mode=hszinc.MODE_JSON)
+    grid_list = hszinc.parse(REMOVE_EXAMPLE_JSON_V2, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     check_remove(grid)
 
 def _check_remove_json_v3(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse(REMOVE_EXAMPLE_JSON_V3, mode=hszinc.MODE_JSON)
+    grid_list = hszinc.parse(REMOVE_EXAMPLE_JSON_V3, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     check_remove(grid)
 
 def test_marker_in_row():
@@ -468,7 +480,7 @@ def test_marker_in_row_json():
 
 def _check_marker_in_row_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'str'},
@@ -479,8 +491,10 @@ def _check_marker_in_row_json(pint_en):
             {'str': 'Marker',       'marker':'m:'},
         ],
     }, mode=hszinc.MODE_JSON)
-    assert_is(grid[0]['marker'], None)
-    assert_is(grid[1]['marker'], hszinc.MARKER)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
+    assert grid[0]['marker'] is None
+    assert grid[1]['marker'] is hszinc.MARKER
 
 def test_bool():
     yield _check_bool, False # without pint
@@ -504,7 +518,7 @@ def test_bool_json():
 
 def _check_bool_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'str'},
@@ -515,6 +529,8 @@ def _check_bool_json(pint_en):
             {'str': 'False','bool':False},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     assert grid[0]['bool'] == True
     assert grid[1]['bool'] == False
 
@@ -572,7 +588,7 @@ def test_number_json():
 
 def _check_number_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'str'},
@@ -591,6 +607,8 @@ def _check_number_json(pint_en):
             {'str': "Not a Number",         'number': u'n:NaN'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     check_number(grid)
 
 def test_string():
@@ -618,7 +636,7 @@ def test_string_json():
 
 def _check_string_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'str'},
@@ -631,6 +649,8 @@ def _check_string_json(pint_en):
             {'str': "With colons",      'strExample': 's:string:with:colons'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
 
     assert len(grid) == 4
     assert grid.pop(0)['strExample'] == ''
@@ -659,7 +679,7 @@ def test_uri_json():
 
 def _check_uri_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'uri'},
@@ -668,6 +688,8 @@ def _check_uri_json(pint_en):
             {'uri': 'u:http://www.vrt.com.au'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
 
     assert len(grid) == 1
     assert grid[0]['uri'] == hszinc.Uri('http://www.vrt.com.au')
@@ -696,7 +718,7 @@ def test_ref_json():
 
 def _check_ref_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'str'},
@@ -707,6 +729,8 @@ def _check_ref_json(pint_en):
             {'str': 'With value',   'ref': 'r:reference With value'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
 
     assert len(grid) == 2
     assert grid[0]['ref'] == hszinc.Ref('a-basic-ref')
@@ -734,7 +758,7 @@ def test_date_json():
 
 def _check_date_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'date'},
@@ -743,6 +767,8 @@ def _check_date_json(pint_en):
             {'date': 'd:2010-03-13'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
 
     assert len(grid) == 1
     assert isinstance(grid[0]['date'], datetime.date)
@@ -773,7 +799,7 @@ def test_time_json():
 
 def _check_time_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'time'},
@@ -784,6 +810,8 @@ def _check_time_json(pint_en):
             {'time': 'h:08:12:05.5'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
 
     assert len(grid) == 3
     row = grid.pop(0)
@@ -849,7 +877,7 @@ def test_datetime_json():
 
 def _check_datetime_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'datetime'},
@@ -863,6 +891,8 @@ def _check_datetime_json(pint_en):
             {'datetime': 't:2010-01-08T05:00:00Z'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
     check_datetime(grid)
 
 def test_list():
@@ -946,7 +976,7 @@ def _check_list_json(pint_en):
     _enable_pint(pint_en)
     # Simpler test case than the ZINC one, since the Python JSON parser
     # will take care of the elements for us.
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'3.0'},
         'cols': [
             {'name': 'list'},
@@ -955,8 +985,10 @@ def _check_list_json(pint_en):
             {'list': ['s:my list', None, True, 'n:1234']}
         ]
     }, mode=hszinc.MODE_JSON)
-    assert len(grid) == 1
+    assert len(grid_list) == 1
+    grid = grid_list[0]
 
+    assert len(grid) == 1
     lst = grid[0]['list']
     assert isinstance(lst, list)
     assert len(lst) == 4
@@ -1007,7 +1039,7 @@ def test_bin_json():
 
 def _check_bin_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'bin'},
@@ -1016,6 +1048,8 @@ def _check_bin_json(pint_en):
             {'bin': 'b:text/plain'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
 
     assert len(grid) == 1
     assert grid[0]['bin'] == hszinc.Bin('text/plain')
@@ -1041,7 +1075,7 @@ def test_coord_json():
 
 def _check_coord_json(pint_en):
     _enable_pint(pint_en)
-    grid = hszinc.parse({
+    grid_list = hszinc.parse({
         'meta': {'ver':'2.0'},
         'cols': [
             {'name':'coord'},
@@ -1050,6 +1084,8 @@ def _check_coord_json(pint_en):
             {'coord': 'c:37.55,-77.45'},
         ],
     }, mode=hszinc.MODE_JSON)
+    assert len(grid_list) == 1
+    grid = grid_list[0]
 
     assert len(grid) == 1
     assert grid[0]['coord'] == hszinc.Coordinate(37.55,-77.45)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,6 +6,7 @@
 
 from __future__ import unicode_literals
 from .pint_enable import _enable_pint
+from nose.tools import assert_is
 
 import warnings
 import hszinc
@@ -13,7 +14,6 @@ import datetime
 import math
 import pytz
 import json
-import six
 import os
 
 # These are examples taken from http://project-haystack.org/doc/Zinc
@@ -100,7 +100,7 @@ def test_unsupported_old():
 
 def _check_unsupported_old(pint_en):
     _enable_pint(pint_en)
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         grid_list = hszinc.parse('''ver:"1.0"
 comment
@@ -116,7 +116,7 @@ def test_unsupported_newer():
 
 def _check_unsupported_newer(pint_en):
     _enable_pint(pint_en)
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         grid_list = hszinc.parse('''ver:"2.5"
 comment
@@ -151,7 +151,7 @@ def test_unsupported_bleedingedge():
 
 def _check_unsupported_bleedingedge(pint_en):
     _enable_pint(pint_en)
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True):
         warnings.simplefilter("always")
         grid_list = hszinc.parse('''ver:"9999.9999"
 comment
@@ -291,7 +291,9 @@ def check_metadata(grid,force_metadata_order=True):
 
 # Test examples used to test every data type defined in the Zinc standard.
 #    Null: N
+#    NA: NA
 #    Marker: M
+#    Remove: R
 #    Bool: T or F (for true, false)
 #    Number: 1, -34, 10_000, 5.4e-45, 9.23kg, 74.2°F, 4min, INF, -INF, NaN
 #    Str: "hello" "foo\nbar\" (uses all standard escape chars as C like languages)
@@ -323,8 +325,8 @@ NULL_EXAMPLE_JSON={
 
 def check_null(grid):
     assert len(grid) == 2
-    assert grid[0]['null'] is None
-    assert grid[1]['null'] is None
+    assert_is(grid[0]['null'], None)
+    assert_is(grid[1]['null'], None)
 
 def test_null():
     yield _check_null, False # without pint
@@ -345,6 +347,105 @@ def _check_null_json(pint_en):
     grid = hszinc.parse(NULL_EXAMPLE_JSON, mode=hszinc.MODE_JSON)
     check_null(grid)
 
+NA_EXAMPLE='''ver:"3.0"
+str,na
+"NA value",NA
+'''
+NA_EXAMPLE_JSON={
+        'meta': {'ver':'3.0'},
+        'cols': [
+            {'name':'str'},
+            {'name':'na'},
+        ],
+        'rows': [
+            {'str': 'NA value', 'na': 'z:'},
+        ],
+}
+
+def check_na(grid):
+    assert len(grid) == 1
+    assert_is(grid[0]['na'], hszinc.NA)
+
+def test_na():
+    yield _check_na, False # without pint
+    yield _check_na, True # with pint
+
+def _check_na(pint_en):
+    _enable_pint(pint_en)
+    grid_list = hszinc.parse(NA_EXAMPLE)
+    assert len(grid_list) == 1
+    check_na(grid_list[0])
+
+def test_na_json():
+    yield _check_na_json, False # without pint
+    yield _check_na_json, True # with pint
+
+def _check_na_json(pint_en):
+    _enable_pint(pint_en)
+    grid = hszinc.parse(NA_EXAMPLE_JSON, mode=hszinc.MODE_JSON)
+    check_na(grid)
+
+REMOVE_EXAMPLE='''ver:"3.0"
+str,remove
+"v2 REMOVE value",R
+"v3 REMOVE value",R
+'''
+REMOVE_EXAMPLE_JSON_V2={
+        'meta': {'ver':'2.0'},
+        'cols': [
+            {'name':'str'},
+            {'name':'remove'},
+        ],
+        'rows': [
+            {'str': 'v2 REMOVE value', 'remove': 'x:'},
+            {'str': 'v3 REMOVE value', 'remove': '-:'},
+        ],
+}
+REMOVE_EXAMPLE_JSON_V3={
+        'meta': {'ver':'3.0'},
+        'cols': [
+            {'name':'str'},
+            {'name':'remove'},
+        ],
+        'rows': [
+            {'str': 'v2 REMOVE value', 'remove': 'x:'},
+            {'str': 'v3 REMOVE value', 'remove': '-:'},
+        ],
+}
+
+def check_remove(grid):
+    assert len(grid) == 2
+    assert_is(grid[0]['remove'], hszinc.REMOVE)
+    assert_is(grid[1]['remove'], hszinc.REMOVE)
+
+def test_remove():
+    yield _check_remove, False # without pint
+    yield _check_remove, True # with pint
+
+def _check_remove(pint_en):
+    _enable_pint(pint_en)
+    grid_list = hszinc.parse(REMOVE_EXAMPLE)
+    assert len(grid_list) == 1
+    check_remove(grid_list[0])
+
+def test_remove_json_v2():
+    yield _check_remove_json_v2, False # without pint
+    yield _check_remove_json_v2, True # with pint
+
+def test_remove_json_v3():
+    yield _check_remove_json_v3, False # without pint
+    yield _check_remove_json_v3, True # with pint
+
+def _check_remove_json_v2(pint_en):
+    _enable_pint(pint_en)
+    grid = hszinc.parse(REMOVE_EXAMPLE_JSON_V2, mode=hszinc.MODE_JSON)
+    check_remove(grid)
+
+def _check_remove_json_v3(pint_en):
+    _enable_pint(pint_en)
+    grid = hszinc.parse(REMOVE_EXAMPLE_JSON_V3, mode=hszinc.MODE_JSON)
+    check_remove(grid)
+
 def test_marker_in_row():
     yield _check_marker_in_row, False # without pint
     yield _check_marker_in_row, True # with pint
@@ -358,8 +459,8 @@ str,marker
 ''')
     assert len(grid_list) == 1
     assert len(grid_list[0]) == 2
-    assert grid_list[0][0]['marker'] is None
-    assert grid_list[0][1]['marker'] is hszinc.MARKER
+    assert_is(grid_list[0][0]['marker'], None)
+    assert_is(grid_list[0][1]['marker'], hszinc.MARKER)
 
 def test_marker_in_row_json():
     yield _check_marker_in_row_json, False # without pint
@@ -378,8 +479,8 @@ def _check_marker_in_row_json(pint_en):
             {'str': 'Marker',       'marker':'m:'},
         ],
     }, mode=hszinc.MODE_JSON)
-    assert grid[0]['marker'] is None
-    assert grid[1]['marker'] is hszinc.MARKER
+    assert_is(grid[0]['marker'], None)
+    assert_is(grid[1]['marker'], hszinc.MARKER)
 
 def test_bool():
     yield _check_bool, False # without pint
@@ -828,7 +929,7 @@ def test_list_v2():
 def _check_list_v2(pint_en):
     _enable_pint(pint_en)
     try:
-        grid_list = hszinc.parse('''ver:"2.0"
+        hszinc.parse('''ver:"2.0"
 ix,list,                                                       dis
 00,[],                                                         "An empty list"
 01,[N],                                                        "A list with a NULL"
@@ -860,8 +961,8 @@ def _check_list_json(pint_en):
     assert isinstance(lst, list)
     assert len(lst) == 4
     assert lst[0] == 'my list'
-    assert lst[1] is None
-    assert lst[2] is True
+    assert_is(lst[1], None)
+    assert_is(lst[2], True)
     assert lst[3] == 1234.0
 
 def test_list_json_v2():
@@ -872,7 +973,7 @@ def _check_list_json_v2(pint_en):
     _enable_pint(pint_en)
     # Version 2.0 does not support lists
     try:
-        grid = hszinc.parse({
+        hszinc.parse({
             'meta': {'ver':'2.0'},
             'cols': [
                 {'name': 'list'},
@@ -1013,9 +1114,9 @@ empty
             'aTimestamp', 'aPlace']
     assert meta['aString'] == 'aValue'
     assert meta['aNumber'] == 3.14159
-    assert meta['aNull'] is None
-    assert meta['aMarker'] is hszinc.MARKER
-    assert meta['anotherMarker'] is hszinc.MARKER
+    assert_is(meta['aNull'], None)
+    assert_is(meta['aMarker'], hszinc.MARKER)
+    assert_is(meta['anotherMarker'], hszinc.MARKER)
     assert isinstance(meta['aQuantity'], hszinc.Quantity)
     assert meta['aQuantity'].value == 123
     assert meta['aQuantity'].unit == 'Hz'
@@ -1051,9 +1152,9 @@ aColumn aString:"aValue" aNumber:3.14159 aNull:N aMarker:M anotherMarker aQuanti
             'aTimestamp', 'aPlace']
     assert meta['aString'] == 'aValue'
     assert meta['aNumber'] == 3.14159
-    assert meta['aNull'] is None
-    assert meta['aMarker'] is hszinc.MARKER
-    assert meta['anotherMarker'] is hszinc.MARKER
+    assert_is(meta['aNull'], None)
+    assert_is(meta['aMarker'], hszinc.MARKER)
+    assert_is(meta['anotherMarker'], hszinc.MARKER)
     assert isinstance(meta['aQuantity'], hszinc.Quantity)
     assert meta['aQuantity'].value == 123
     assert meta['aQuantity'].unit == 'Hz'
@@ -1117,7 +1218,7 @@ xyz
     assert len(grid_list) == 1
     assert len(grid_list[0]) == 1
     assert list(grid_list[0].metadata.keys()) == ['tag', 'foo']
-    assert grid_list[0].metadata['tag'] is hszinc.MARKER
+    assert_is(grid_list[0].metadata['tag'], hszinc.MARKER)
     assert grid_list[0].metadata['foo'] == 'bar'
     assert list(grid_list[0].column.keys()) == ['xyz']
     assert grid_list[0][0]['xyz'] == 'val'
@@ -1136,7 +1237,7 @@ N
     assert len(grid_list[0]) == 1
     assert len(grid_list[0].metadata) == 0
     assert list(grid_list[0].column.keys()) == ['val']
-    assert grid_list[0][0]['val'] is None
+    assert_is(grid_list[0][0]['val'], None)
 
 def test_nodehaystack_04():
     yield _check_nodehaystack_04, False # without pint
@@ -1183,7 +1284,7 @@ C(12,-34),C(0.123,-.789),C(84.5,-77.45),C(-90,180)
     row = grid.pop(0)
     assert row['a'] == True
     assert row['b'] == False
-    assert row['c'] is None
+    assert_is(row['c'], None)
     assert row['d'] == -99.0
     row = grid.pop(0)
     assert row['a'] == 2.3
@@ -1201,8 +1302,8 @@ C(12,-34),C(0.123,-.789),C(84.5,-77.45),C(-90,180)
     assert row['c'] == hszinc.Quantity(4, 's')
     assert row['d'] == hszinc.Quantity(-2.5, 'min')
     row = grid.pop(0)
-    assert row['a'] is hszinc.MARKER
-    assert row['b'] is hszinc.REMOVE
+    assert_is(row['a'], hszinc.MARKER)
+    assert_is(row['b'], hszinc.REMOVE)
     assert row['c'] == hszinc.Bin('image/png')
     assert row['d'] == hszinc.Bin('image/png')
     row = grid.pop(0)
@@ -1329,9 +1430,9 @@ a
             datetime.datetime(2010,2,3,4,5,6))
     assert grid.metadata['c'] == pytz.timezone('Europe/London').localize(\
             datetime.datetime(2009,12,3,4,5,6))
-    assert grid.metadata['foo'] is hszinc.MARKER
-    assert grid.metadata['bar'] is hszinc.MARKER
-    assert grid.metadata['baz'] is hszinc.MARKER
+    assert_is(grid.metadata['foo'], hszinc.MARKER)
+    assert_is(grid.metadata['bar'], hszinc.MARKER)
+    assert_is(grid.metadata['baz'], hszinc.MARKER)
     assert list(grid.column.keys()) == ['a']
     assert grid.pop(0)['a'] == 3.814697265625E-6
     assert grid.pop(0)['a'] == pytz.utc.localize(\
@@ -1362,7 +1463,7 @@ Bin(text/html; a=foo; bar="sep"),Bin(text/html; charset=utf8)
     assert len(grid) == 3
     assert list(grid.metadata.keys()) == ['bg','mark']
     assert grid.metadata['bg'] == hszinc.Bin('image/jpeg')
-    assert grid.metadata['mark'] is hszinc.MARKER
+    assert_is(grid.metadata['mark'], hszinc.MARKER)
     assert list(grid.column.keys()) == ['file1','file2']
     assert list(grid.column['file1'].keys()) == ['dis','icon']
     assert grid.column['file1']['dis'] == 'F1'
@@ -1371,7 +1472,7 @@ Bin(text/html; a=foo; bar="sep"),Bin(text/html; charset=utf8)
     assert grid.column['file2']['icon'] == hszinc.Bin('image/jpg')
     row = grid.pop(0)
     assert row['file1'] == hszinc.Bin('text/plain')
-    assert row['file2'] is None
+    assert_is(row['file2'], None)
     row = grid.pop(0)
     assert row['file1'] == 4
     assert row['file2'] == hszinc.Bin('image/png')
@@ -1401,29 +1502,29 @@ a, b, c
     assert len(grid.metadata) == 0
     assert list(grid.column.keys()) == ['a','b','c']
     row = grid.pop(0)
-    assert row['a'] is None
+    assert_is(row['a'], None)
     assert row['b'] == 1
     assert row['c'] == 2
     row = grid.pop(0)
     assert row['a'] == 3
-    assert row['b'] is None
+    assert_is(row['b'], None)
     assert row['c'] == 5
     row = grid.pop(0)
     assert row['a'] == 6
     assert row['b'] == 7000
-    assert row['c'] is None
+    assert_is(row['c'], None)
     row = grid.pop(0)
-    assert row['a'] is None
-    assert row['b'] is None
+    assert_is(row['a'], None)
+    assert_is(row['b'], None)
     assert row['c'] == 10
     row = grid.pop(0)
-    assert row['a'] is None
-    assert row['b'] is None
-    assert row['c'] is None
+    assert_is(row['a'], None)
+    assert_is(row['b'], None)
+    assert_is(row['c'], None)
     row = grid.pop(0)
     assert row['a'] == 14
-    assert row['b'] is None
-    assert row['c'] is None
+    assert_is(row['b'], None)
+    assert_is(row['c'], None)
 
 
 # Scalar parsing tests… no need to be exhaustive here because the grid tests
@@ -1545,7 +1646,7 @@ def test_malformed_grid_meta():
 def _check_malformed_grid_meta(pint_en):
     _enable_pint(pint_en)
     try:
-        grid_list = hszinc.parse('''ver:"2.0" ThisIsNotATag
+        hszinc.parse('''ver:"2.0" ThisIsNotATag
 empty
 
 ''')
@@ -1561,7 +1662,7 @@ def test_malformed_col_meta():
 def _check_malformed_col_meta(pint_en):
     _enable_pint(pint_en)
     try:
-        grid_list = hszinc.parse('''ver:"2.0"
+        hszinc.parse('''ver:"2.0"
 c1 goodSoFar, c2 WHOOPSIE
 ,
 ''')
@@ -1577,7 +1678,7 @@ def test_malformed_row():
 def _check_malformed_row(pint_en):
     _enable_pint(pint_en)
     try:
-        grid_list = hszinc.parse('''ver:"2.0"
+        hszinc.parse('''ver:"2.0"
 c1, c2
 1, "No problems here"
 2, We should fail here


### PR DESCRIPTION
Hello,

I propose some modification:

1) Pytest 4.0 hide all the test with `yield()`
I change the tests like this:
```
@pytest.mark.parametrize("pint_en", [False,True])
def test_simple(pint_en):
   ...
```

The tests in `test_datatype.py` must be updated.

2) The method `hszinc.parse()` is not consistent

To implement the rest protocol, 
I would like to call 
```
list_grid=hszinc.parse(body,header["Content-Type"])
```
It's not possible. Because the `hszinc.MODE_ZINC` and `hszinc.MODE_JSON` is not a MIME type, and the return value change if the type is JSON or Zinc.
`parse()` function return a list of grid or one grid for JSON, but allways a list of grid for Zinc.

This fix normalise the return, to always return a list of grid and accept the 'Content-Type'.

3) I add the `haystack dict()`
For zinc and json

I will implement a grid in a gird